### PR TITLE
Convert tabs to spaces and fix default updateFreq value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example config.json
 Fields:
 - `accessory` must be "PurpleAir" (required).
 - `purpleID` PurpleAir Station ID (a number).
-- `updateFreq` minimum number of seconds between reads from PurpleAir API (a number - default is 90 seconds)
+- `updateFreq` minimum number of seconds between reads from PurpleAir API (a number - default is 300 seconds, i.e. 5 minutes)
 - `name` Is the name of accessory (required).
 
 To find your specific "PURPLE_AIR_STATION_ID" (a string):


### PR DESCRIPTION
This makes sure that the indentation looks the same in all editing environments. (For example, GitHub renders tabs by default as 8 characters, making a lot of alignments off, when the author was expecting 4 characters.)

Also fixes the incorrect default updateFreq value documentation in README.